### PR TITLE
Support for Django 1.5-1.8

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,6 @@ dist/
 build/
 *.egg-info/
 /env/
+htmlcov/
+
+.coverage

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,8 +11,8 @@ env:
   - DJANGO_VERSION=1.4
   - DJANGO_VERSION=1.5
   - DJANGO_VERSION=1.6
-  - DJANGO_VERSION=1.7
-  - DJANGO_VERSION=1.8
+  - if [[ $TRAVIS_PYTHON_VERSION == 2.7 ]]; then DJANGO_VERSION=1.7; fi
+  - if [[ $TRAVIS_PYTHON_VERSION == 2.7 ]]; then DJANGO_VERSION=1.8; fi
 
 install:
   - pip install -r requirements.txt

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,16 +3,16 @@ language: python
 sudo: false
 
 env:
-    - TOX_ENV=py26-django13
-    - TOX_ENV=py26-django14
-    - TOX_ENV=py26-django15
-    - TOX_ENV=py26-django16
-    - TOX_ENV=py27-django13
-    - TOX_ENV=py27-django14
-    - TOX_ENV=py27-django15
-    - TOX_ENV=py27-django16
-    - TOX_ENV=py27-django17
-    - TOX_ENV=py27-django18
+  - TOX_ENV=py26-django13
+  - TOX_ENV=py26-django14
+  - TOX_ENV=py26-django15
+  - TOX_ENV=py26-django16
+  - TOX_ENV=py27-django13
+  - TOX_ENV=py27-django14
+  - TOX_ENV=py27-django15
+  - TOX_ENV=py27-django16
+  - TOX_ENV=py27-django17
+  - TOX_ENV=py27-django18
 
 install:
   - pip install tox

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ env:
   - DJANGO_VERSION=1.8
 
 install:
-  - pip install -q Django==$DJANGO_VERSION --use-mirrors
-  - pip install -q -r requirements.txt --use-mirrors
+  - pip install -r requirements.txt
+  - pip install -U Django==$DJANGO_VERSION
 
 script: python runtests.py

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,21 @@
 language: python
+
+sudo: false
+
 python:
   - "2.6"
   - "2.7"
+
 env:
   - DJANGO_VERSION=1.3
   - DJANGO_VERSION=1.4
+  - DJANGO_VERSION=1.5
+  - DJANGO_VERSION=1.6
+  - DJANGO_VERSION=1.7
+  - DJANGO_VERSION=1.8
+
 install:
   - pip install -q Django==$DJANGO_VERSION --use-mirrors
   - pip install -q -r requirements.txt --use-mirrors
+
 script: python manage.py test

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,4 +18,4 @@ install:
   - pip install -q Django==$DJANGO_VERSION --use-mirrors
   - pip install -q -r requirements.txt --use-mirrors
 
-script: python manage.py test
+script: python runtests.py

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,20 +2,20 @@ language: python
 
 sudo: false
 
-python:
-  - "2.6"
-  - "2.7"
-
 env:
-  - DJANGO_VERSION=1.3
-  - DJANGO_VERSION=1.4
-  - DJANGO_VERSION=1.5
-  - DJANGO_VERSION=1.6
-  - if [[ $TRAVIS_PYTHON_VERSION == 2.7 ]]; then DJANGO_VERSION=1.7; fi
-  - if [[ $TRAVIS_PYTHON_VERSION == 2.7 ]]; then DJANGO_VERSION=1.8; fi
+    - TOX_ENV=py26-django13
+    - TOX_ENV=py26-django14
+    - TOX_ENV=py26-django15
+    - TOX_ENV=py26-django16
+    - TOX_ENV=py27-django13
+    - TOX_ENV=py27-django14
+    - TOX_ENV=py27-django15
+    - TOX_ENV=py27-django16
+    - TOX_ENV=py27-django17
+    - TOX_ENV=py27-django18
 
 install:
-  - pip install -r requirements.txt
-  - pip install -U Django==$DJANGO_VERSION
+  - pip install tox
 
-script: python runtests.py
+script:
+  - tox -e $TOX_ENV

--- a/README.md
+++ b/README.md
@@ -1,5 +1,11 @@
-Basic geospatial helpers for Django
+django-geosimple [![travis][travis-image]][travis-url] [![pypi][pypi-image]][pypi-url]
 ===================================
+> Basic geospatial helpers for Django
+
+### Supports
+
+ - Python 2.6, 2.7
+ - Django 1.3 up to 1.8
 
 
 GeoDjango is an incredibly powerful set of extensions to Django for handling complex geospatial data. However, it has a long list of prerequisites (a spatial database such as PostgreSQL with PostGIS, GEOS, a specialised database backend, etc). For many projects that have only basic geospatial requirements, the overhead of getting GeoDjango up and running is painful.
@@ -122,3 +128,10 @@ If you've already filtered the points by distance, you don't need to supply the 
 ### Distance annotation
 
 If either of the in-memory filtering or sorting methods are used, each item in the queryset will be annotated with the distance from the given point. The property used is the name of the field with `_distance` appended. So, in the example above, the property will be named `location_distance`. This will be a `geopy.Distance` instance. You can force these annotations to be added by calling `with_distance_annotations`, passing a location.
+
+
+[travis-image]: https://travis-ci.org/dabapps/django-geosimple.svg?branch=master
+[travis-url]: https://travis-ci.org/dabapps/django-geosimple
+
+[pypi-image]: https://badge.fury.io/py/django-geosimple.svg
+[pypi-url]: https://pypi.python.org/pypi/django-geosimple/

--- a/geosimple/__init__.py
+++ b/geosimple/__init__.py
@@ -3,4 +3,4 @@ from geosimple.managers import GeoManager
 from geopy.distance import Distance
 
 
-__version__ = '1.0.0'
+__version__ = '1.0.1'

--- a/geosimple/managers.py
+++ b/geosimple/managers.py
@@ -97,11 +97,7 @@ class GeoQuerySet(models.query.QuerySet):
 class GeoManager(models.Manager):
 
     def get_query_set(self):
-        # Django 1.5
-        # https://docs.djangoproject.com/en/1.5/topics/db/managers/#modifying-initial-manager-querysets
         return GeoQuerySet(self.model)
 
     def get_queryset(self):
-        # Django 1.6
-        # https://docs.djangoproject.com/en/1.6/topics/db/managers/#modifying-initial-manager-querysets
-        return GeoQuerySet(self.model)
+        return self.get_query_set()

--- a/geosimple/managers.py
+++ b/geosimple/managers.py
@@ -97,4 +97,11 @@ class GeoQuerySet(models.query.QuerySet):
 class GeoManager(models.Manager):
 
     def get_query_set(self):
+        # Django 1.5
+        # https://docs.djangoproject.com/en/1.5/topics/db/managers/#modifying-initial-manager-querysets
+        return GeoQuerySet(self.model)
+
+    def get_queryset(self):
+        # Django 1.6
+        # https://docs.djangoproject.com/en/1.6/topics/db/managers/#modifying-initial-manager-querysets
         return GeoQuerySet(self.model)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,2 @@
 Django==1.8
-geopy==0.94.2
-python-geohash==0.8.5
-flake8==2.5.1
-coverage==4.0.3
+-r requirements/requirements-tests.txt

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,5 @@
 Django==1.8
--r requirements/requirements-tests.txt
+geopy==0.94.2
+python-geohash==0.8.5
+flake8==2.5.1
+coverage==4.0.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ Django==1.8
 geopy==1.11.0
 python-geohash==0.8.5
 flake8==2.5.1
+coverage==4.0.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 Django==1.8
-geopy==1.11.0
+geopy==0.94.2
 python-geohash==0.8.5
 flake8==2.5.1
 coverage==4.0.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-Django>=1.3
-geopy==0.94.2
+Django==1.8
+geopy==1.11.0
 python-geohash==0.8.5
 flake8==2.5.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 Django>=1.3
 geopy==0.94.2
 python-geohash==0.8.5
+flake8==2.5.1

--- a/requirements/requirements-tests.txt
+++ b/requirements/requirements-tests.txt
@@ -1,4 +1,0 @@
-geopy==0.94.2
-python-geohash==0.8.5
-flake8==2.5.1
-coverage==4.0.3

--- a/requirements/requirements-tests.txt
+++ b/requirements/requirements-tests.txt
@@ -1,0 +1,4 @@
+geopy==0.94.2
+python-geohash==0.8.5
+flake8==2.5.1
+coverage==4.0.3

--- a/runtests.py
+++ b/runtests.py
@@ -6,6 +6,7 @@ import logging
 
 logger = logging.getLogger(__name__)
 FLAKE8_ARGS = ['geosimple/', '--ignore=E501', '--exclude=__init__.py']
+COVERAGE_ARGS = ['--source=geosimple', '--omit=**tests**', 'manage.py', 'test']
 
 
 def exit_on_failure(command, message=None):
@@ -14,17 +15,19 @@ def exit_on_failure(command, message=None):
 
 
 def flake8_main(args):
-    print('Running: flake8', args)
+    print 'Running: flake8 %s' % " ".join(str(x) for x in args)
     command = subprocess.call(['flake8'] + args)
     logger.info('Success. flake8 passed.') if command else None
     return command
 
 
-def django_main():
-    print('Running: django tests')
-    command = subprocess.call(['python', 'manage.py', 'test'])
+def run_tests_coverage(args):
+    print 'Running: coverage %s' % " ".join(str(x) for x in args)
+    command = subprocess.call(['coverage', 'run'] + args)
+    logger.info('Success. Coverage generated.') if command else None
+    command = subprocess.call(['coverage', 'report'])
     return command
 
 
 exit_on_failure(flake8_main(FLAKE8_ARGS))
-exit_on_failure(django_main())
+exit_on_failure(run_tests_coverage(COVERAGE_ARGS))

--- a/runtests.py
+++ b/runtests.py
@@ -1,0 +1,30 @@
+#!/usr/bin/env python
+import sys
+import subprocess
+import logging
+
+
+logger = logging.getLogger(__name__)
+FLAKE8_ARGS = ['geosimple/', '--ignore=E501', '--exclude=__init__.py']
+
+
+def exit_on_failure(command, message=None):
+    if command:
+        sys.exit(command)
+
+
+def flake8_main(args):
+    print('Running: flake8', args)
+    command = subprocess.call(['flake8'] + args)
+    logger.info('Success. flake8 passed.') if command else None
+    return command
+
+
+def django_main():
+    print('Running: django tests')
+    command = subprocess.call(['python', 'manage.py', 'test'])
+    return command
+
+
+exit_on_failure(flake8_main(FLAKE8_ARGS))
+exit_on_failure(django_main())

--- a/runtests.py
+++ b/runtests.py
@@ -21,13 +21,17 @@ def flake8_main(args):
     return command
 
 
-def run_tests_coverage(args):
-    print 'Running: coverage %s' % " ".join(str(x) for x in args)
+def run_tests(args):
     command = subprocess.call(['coverage', 'run'] + args)
-    logger.info('Success. Coverage generated.') if command else None
+    return command
+
+
+def run_coverage():
     command = subprocess.call(['coverage', 'report'])
+    logger.info('Success. Coverage generated.') if command else None
     return command
 
 
 exit_on_failure(flake8_main(FLAKE8_ARGS))
-exit_on_failure(run_tests_coverage(COVERAGE_ARGS))
+exit_on_failure(run_tests(COVERAGE_ARGS))
+exit_on_failure(run_coverage())

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ url = 'http://github.com/dabapps/django-geosimple/'
 author = 'Jamie Matthews'
 author_email = 'jamie@dabapps.com'
 license = 'BSD'
-install_requires = ['geopy==1.11.0', 'python-geohash==0.8.5']
+install_requires = ['geopy==0.94.2', 'python-geohash==0.8.5']
 
 
 def get_version(package):

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ url = 'http://github.com/dabapps/django-geosimple/'
 author = 'Jamie Matthews'
 author_email = 'jamie@dabapps.com'
 license = 'BSD'
-install_requires = ['geopy==0.94.2','python-geohash==0.8.5']
+install_requires = ['geopy==1.11.0', 'python-geohash==0.8.5']
 
 
 def get_version(package):

--- a/testsettings.py
+++ b/testsettings.py
@@ -8,3 +8,5 @@ DATABASES = {
 INSTALLED_APPS = (
     'geosimple.tests',
 )
+
+SECRET_KEY = "django_geosimple"

--- a/tox.ini
+++ b/tox.ini
@@ -8,10 +8,10 @@ commands = python runtests.py
 setenv =
       PYTHONDONTWRITEBYTECODE=1
 deps =
+      -rrequirements/requirements-tests.txt
       django13: Django==1.3.7
       django14: Django==1.4.22
       django15: Django==1.5.12
       django16: Django==1.6.11
       django17: Django==1.7.11
       django18: Django==1.8.8
-      -rrequirements/requirements-tests.txt

--- a/tox.ini
+++ b/tox.ini
@@ -1,17 +1,17 @@
 [tox]
 envlist =
-       {py26,py27}-django{13,14,15,16},
-       {py27}-django{17,18},
+      {py26,py27}-django{13,14,15,16},
+      {py27}-django{17,18},
 
 [testenv]
 commands = ./runtests.py
 setenv =
-       PYTHONDONTWRITEBYTECODE=1
+      PYTHONDONTWRITEBYTECODE=1
 deps =
-        django13: Django==1.3.7
-        django14: Django==1.4.22
-        django15: Django==1.5.12
-        django16: Django==1.6.11
-        django17: Django==1.7.11
-        django18: Django==1.8.8
-        -rrequirements.txt
+      django13: Django==1.3.7
+      django14: Django==1.4.22
+      django15: Django==1.5.12
+      django16: Django==1.6.11
+      django17: Django==1.7.11
+      django18: Django==1.8.8
+      -rrequirements/requirements-tests.txt

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,17 @@
+[tox]
+envlist =
+       {py26,py27}-django{13,14,15,16},
+       {py27}-django{17,18},
+
+[testenv]
+commands = ./runtests.py
+setenv =
+       PYTHONDONTWRITEBYTECODE=1
+deps =
+        django13: Django==1.3.7
+        django14: Django==1.4.22
+        django15: Django==1.5.12
+        django16: Django==1.6.11
+        django17: Django==1.7.11
+        django18: Django==1.8.8
+        -rrequirements.txt

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@ envlist =
       {py27}-django{17,18},
 
 [testenv]
-commands = ./runtests.py
+commands = python runtests.py
 setenv =
       PYTHONDONTWRITEBYTECODE=1
 deps =


### PR DESCRIPTION
#### To do

 - [x] Check that it works with Django 1.3 to 1.8
 - [x] Update `install_requires` in `setup.py`
 - [x] Enable Travis
 - [x] Add Coverage
 - [x] Bump Version

#### Notes
It looks like `get_query_set()` was changed to `get_queryset()` from Django 1.5 to 1.6. More info at the docs.

#### Links
 - [Django 1.5 Docs - Modifying initial Manager QuerySets](https://docs.djangoproject.com/en/1.5/topics/db/managers/#modifying-initial-manager-querysets).
 - [Django 1.6 Docs - Modifying initial Manager QuerySets](https://docs.djangoproject.com/en/1.6/topics/db/managers/#modifying-initial-manager-querysets)